### PR TITLE
Automate product identifier test

### DIFF
--- a/test/pageObjects/common.page.js
+++ b/test/pageObjects/common.page.js
@@ -1,0 +1,37 @@
+const MAX_TIMEOUT = 30000;
+var CommonPage = function(){
+    var that = this;
+
+    /**
+     * define elements
+     */
+     var elementsMap = this.elementsMap =  {
+        'search.input' : '#global-search'
+     };
+
+    /**
+     * define or overwrite page methods
+     */
+     this.goToPage = function(path) {
+         browser.url(path);
+         // Assert the element which is available for all pages
+         // Assuming search box will be there for all web pages
+         that.waitForElementPresent(elementsMap['search.input']);
+     };
+
+     this.waitForElementPresent = function(selector,timeout) {
+        var timeOut = timeout ? timeout : MAX_TIMEOUT;
+        browser.waitForVisible(selector,timeOut);
+     };
+
+     this.waitAndGetText = function(selector, timeout) {
+        var timeOut = timeout ? timeout : MAX_TIMEOUT;
+        that.waitForElementPresent(selector, timeOut);
+        return browser.getText(selector);
+     };
+
+
+
+};
+
+module.exports = CommonPage;

--- a/test/pageObjects/item.page.js
+++ b/test/pageObjects/item.page.js
@@ -1,11 +1,28 @@
-var ItemPage = {
+const CommonPage = require('../../test/pageObjects/common.page.js');
+const commonPage = new CommonPage();
+var ItemPage = function(){
+    var that = this;
+
     /**
      * define elements
      */
+     var elementsMap = this.elementsMap =  {
+        'item.identifiers.itemNum' : '//div[contains(@class,"product-identifiers-value")][1]', // XPath Selector
+        // Ideally identifiers value's element should be searched based on key's text name. e.g. - Model #
+        'item.identifiers.modelNum' : '//div[contains(@class,"product-identifiers-value")][2]' ,
+        'item.identifiers.SKU' : '//div[contains(@class,"product-identifiers-value")][3]',
+        'item.identifiers.UPC' : '//div[contains(@class,"product-identifiers-value")][4]',
+     };
 
     /**
      * define or overwrite page methods
      */
+     this.goToItemPage = function(path) {
+         path = 'ip/' + path;
+         commonPage.goToPage(path);
+     };
+
+
 
 };
 

--- a/test/specs/item.specs.js
+++ b/test/specs/item.specs.js
@@ -1,44 +1,38 @@
-const itemPage = require('../../test/pageObjects/item.page.js');
+const assert = require('assert');
+
+const CommonPage = require('../../test/pageObjects/common.page.js');
+const commonPage = new CommonPage();
+
+const ItemPage = require('../../test/pageObjects/item.page.js');
+const itemPage = new ItemPage();
 
 beforeEach(function(){
-    //  Pre-conditions
-    //  Navigate to https://www.wallmart.ca/en
-    //  Assert on url and content
+    // Navigate to given item web page
+    // https://www.walmart.ca/en/ip/intex-metal-frame-pool/6000166640889
+    itemPage.goToItemPage('intex-metal-frame-pool/6000166640889');
 });
 
 describe('Product identifiers should be displayed correctly', function() {
-    it('Navigate Intex Swimming Pool item web page', function() {
-        // Navigate to given item web page
-        // https://www.walmart.ca/en/ip/intex-metal-frame-pool/6000166640889
-        // Wait for page to load
-    });
 
+    // Assert each product identifiers value with database value
     it('Assert the product identifiers', function(){
-        // Assert each product identifiers value with database value
 
         //  Assume database query / api returns an object
-        //  resp = {
-        //     'itemNum': '31321863, 30885665',
-        //     'modelNum': '28211MW',
-        //     'SKU' :  '10320406',
-        //      'UPC' : '7825728211'
-        //      };
+        const  resp = {
+             'itemNum': '31321863, 30885665',
+             'modelNum': '28211MW',
+             'SKU' :  '10320406',
+              'UPC' : '7825728211'
+        };
 
-        // elements Selector of Alert page are defined on ../test/pageObjects/alert.page.js
-
-        // assert.strictEqual(AlertPage.identifiers.itemNum, resp.itemNum);
-        // assert.strictEqual(AlertPage.identifiers.modelNum, resp.modelNum);
-        // assert.strictEqual(AlertPage.identifiers.SKU, resp.SKU);
-        // assert.strictEqual(AlertPage.identifiers.UPC, resp.UPC);
+        assert.strictEqual(commonPage.waitAndGetText(itemPage.elementsMap['item.identifiers.itemNum']), resp.itemNum);
+        assert.strictEqual(commonPage.waitAndGetText(itemPage.elementsMap['item.identifiers.modelNum']), resp.modelNum);
+        assert.strictEqual(commonPage.waitAndGetText(itemPage.elementsMap['item.identifiers.SKU']), resp.SKU);
+        assert.strictEqual(commonPage.waitAndGetText(itemPage.elementsMap['item.identifiers.UPC']), resp.UPC);
     });
 });
 
 describe('Product specifications should be displayed correctly', function() {
-    it('Navigate Intex Swimming Pool item web page', function() {
-        // Navigate to given item web page
-        // https://www.walmart.ca/en/ip/intex-metal-frame-pool/6000166640889
-        // Wait for page to load
-    });
 
     it('Assert the product specifications', function(){
         // Assert each product specification value with database value
@@ -59,11 +53,6 @@ describe('Product specifications should be displayed correctly', function() {
 });
 
 describe('User should able to write a review', function() {
-    it('Navigate Intex Swimming Pool item web page', function() {
-        // Navigate to given item web page
-        // https://www.walmart.ca/en/ip/intex-metal-frame-pool/6000166640889
-        // Wait for page to load
-    });
 
     it('Click on Write a review', function(){
         // browser.cick(ItemPage.addReviewButton);

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -82,7 +82,7 @@ exports.config = {
     // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
     // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
     // gets prepended directly.
-    baseUrl: 'https://www.wallmart.ca',
+    baseUrl: 'https://www.walmart.ca/en/',
     //
     // Default timeout for all waitFor* commands.
     waitforTimeout: 10000,
@@ -133,7 +133,8 @@ exports.config = {
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
-        ui: 'bdd'
+        ui: 'bdd',
+        timeout: 60000
     },
     //
     // =====


### PR DESCRIPTION
Increase step timeout

- Increased step timeout to 60 sec from default value 10 sec

Automate product identifier test

- Added common.page.js to add common page methods like goToPage, waitForElementVisible, waitAndGetText
- Added elementsMap for item page in item.page.js
- Added steps in item.specs.js